### PR TITLE
feat: Add `@typescript-eslint/no-misused-promises` rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,11 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'error',
         '@typescript-eslint/consistent-type-imports': 'warn',
         '@typescript-eslint/ban-types': 'error',
+        "@typescript-eslint/no-misused-promises": [2, {
+            "checksVoidReturn": {
+              "attributes": false
+            }
+        }],
         'react/hook-use-state': 'warn',
         'react/self-closing-comp': [
             'warn',


### PR DESCRIPTION
This PR allows having an asynchronous callback to JSX elements:
```typescript
const onChange = async () => {};
const input = <input onChange={onChange} />;
```
instead of:
```typescript
const onChange = (async () => {})();
const input = <input onChange={onChange} />;
```